### PR TITLE
(maint) switch from jessie to stretch

### DIFF
--- a/pg/Dockerfile
+++ b/pg/Dockerfile
@@ -2,10 +2,10 @@ FROM postgres:11
 MAINTAINER Justin Holguin <justin.holguin@puppet.com>
 
 RUN apt-get update && apt-get install -y wget gnupg
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
   && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
        apt-key add - \
-  && echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ jessie-2ndquadrant main" > /etc/apt/sources.list.d/2ndquadrant.list \
+  && echo "deb [arch=amd64] http://packages.2ndquadrant.com/pglogical/apt/ stretch-2ndquadrant main" > /etc/apt/sources.list.d/2ndquadrant.list \
   && wget --quiet -O - http://packages.2ndquadrant.com/pglogical/apt/AA7A6805.asc | apt-key add - \
   && apt-get update \
   && apt-get install -y postgresql-11-pglogical


### PR DESCRIPTION
The base for the postgres11 image has switched to stretch, so this updates the dockerfile to include the right pglogical build parts.